### PR TITLE
Add Jest TypeScript support

### DIFF
--- a/templates/index.spec.ts
+++ b/templates/index.spec.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/svelte';
+import index from './index.svelte';
+
+test('shows proper heading when rendered', () => {
+  const { getByText } = render(index);
+  expect(getByText('Hello world!')).toBeInTheDocument();
+});

--- a/templates/tsconfig.spec.json
+++ b/templates/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": false,
+    "lib": [
+      "es2020",
+      "DOM"
+    ]
+  },
+  "exclude": [
+    "src/**"
+  ],
+  "include": [
+    "src/**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
Implement TypeScript support to the existing Adder.

### Acceptance Criteria
- [x] TypeScript support for Jest specs on SvelteKit projects