### PR TITLE
Rollback JSON-C changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ npm init svelte@next
 
 Once that is set up, run this command in your project directory to set up Jest:
 
+> ❗️ __When running with TypeScript support enabled, remove comments within `tsconfig.json` or the adder will fail. This is a known limitation of [Preset](https://usepreset.dev/), as it relies upon JSON.parse.__
+
 ```sh
 npx apply rossyman/svelte-add-jest # --no-ssh
 ```

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "Brady Wiggins (https://github.com/FractalHQ)"
   ],
   "preset": "preset.ts",
-  "dependencies": {
-    "comment-json": "^4.1.0"
-  },
   "devDependencies": {
     "apply": "^0.2.13"
   }

--- a/preset.ts
+++ b/preset.ts
@@ -1,4 +1,3 @@
-import { assign, parse, stringify } from 'comment-json';
 import { Preset, color } from 'apply';
 
 type Dependencies = {
@@ -188,10 +187,12 @@ class SvelteJestAdder extends Adder {
       .withTitle('Enabling Jest DOM Support')
       .if(() => this.getConfiguration('jest-dom'));
 
-    Preset.edit('tsconfig.json').update((content) => 
-      stringify(assign(parse(content), { exclude: ['src/**/*.spec.ts'] }), null, 4))
-        .withTitle('Modifying TypeScript config for project')
-        .if(() => this.getConfiguration('ts'));
+    Preset
+      .editJson('tsconfig.json').merge({
+        exclude: ['src/**/*.spec.ts']
+      })
+      .withTitle('Modifying TypeScript config for project')
+      .if(() => this.getConfiguration('ts'));
 
     Preset
       .editJson('jest.config.json').merge({


### PR DESCRIPTION
Relates to #5 

### Changelog
- Rollback JSON-C Changes as external dependencies aren't supported yet by [Preset](https://preset.dev)