### PR TITLE
Use single quotes in example test

### DIFF
--- a/templates/index.spec.js
+++ b/templates/index.spec.js
@@ -1,8 +1,8 @@
-import "@testing-library/jest-dom/extend-expect";
-import { render } from "@testing-library/svelte";
-import index from "./index.svelte";
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/svelte';
+import index from './index.svelte';
 
-test("shows proper heading when rendered", () => {
+test('shows proper heading when rendered', () => {
   const { getByText } = render(index);
-  expect(getByText("Hello world!")).toBeInTheDocument();
+  expect(getByText('Hello world!')).toBeInTheDocument();
 });


### PR DESCRIPTION
Svelte projects use single quotes for strings, so this file is formatted differently than the others in a new project. The `.ts` version already uses single quotes: https://github.com/rossyman/svelte-add-jest/blob/main/templates/index.spec.ts