### PR TITLE
Add test environment config

### DIFF
--- a/templates/index.spec.js
+++ b/templates/index.spec.js
@@ -1,8 +1,12 @@
-import "@testing-library/jest-dom/extend-expect";
-import { render } from "@testing-library/svelte";
-import index from "./index.svelte";
+/**
+ * @jest-environment jsdom
+ */
 
-test("shows proper heading when rendered", () => {
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/svelte';
+import index from './index.svelte';
+
+test('shows proper heading when rendered', () => {
   const { getByText } = render(index);
-  expect(getByText("Hello world!")).toBeInTheDocument();
+  expect(getByText('Hello world!')).toBeInTheDocument();
 });

--- a/templates/index.spec.ts
+++ b/templates/index.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/svelte';
 import index from './index.svelte';


### PR DESCRIPTION
Jest 27 changed the default test environment to Node. We need to set it to jsdom to keep the test passing