### PR TITLE
[bug: #19, #22] Fix examples and v27 Jest support / ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ After the preset runs,
 
 ### ⚙️ Options
 
-| Description        | Flag            | Negated            | Default |
-| ------------------ | --------------- | ------------------ | ------- |
-| Interactive Mode   | `--interaction` | `--no-interaction` | True    |
-| Jest DOM Support   | `--jest-dom`    | `--no-jest-dom`    | True    |
-| Typescript Support | `--ts`          | `--no-ts`          | False   |
-| Generate Example   | `--examples`    | `--no-examples`    | True    |
+| Description               | Flag            | Negated            | Default |
+| ------------------------- | --------------- | ------------------ | ------- |
+| Interactive Mode          | `--interaction` | `--no-interaction` | True    |
+| Jest DOM Support          | `--jest-dom`    | `--no-jest-dom`    | True    |
+| Typescript Support        | `--ts`          | `--no-ts`          | False   |
+| JSDOM Jest Env by Default | `--jsdom`       | `--jsdom`          | True    |
+| Generate Example          | `--examples`    | `--no-examples`    | True    |
 
 ### 📑 Relevant Documentation
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rossyman/svelte-add-jest",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "SvelteKit adder for Jest unit testing",
   "license": "MIT",
   "keywords": [

--- a/templates/index-dom.spec.js
+++ b/templates/index-dom.spec.js
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/svelte';
+import Index from './index.svelte';
+
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * An example test suite outlining the usage of
+ * `describe()`, `beforeEach()`, `test()` and `expect()`
+ *
+ * @see https://jestjs.io/docs/getting-started
+ * @see https://github.com/testing-library/jest-dom
+ */
+
+describe('Index', () => {
+
+  let renderedComponent;
+
+  beforeEach(() => {
+    renderedComponent = render(Index);
+  });
+
+  describe('once the component has been rendered', () => {
+
+    test('should show the proper heading', () => {
+      expect(renderedComponent.getByText('Welcome to SvelteKit')).toBeInTheDocument();
+    });
+
+  });
+
+});

--- a/templates/index-dom.spec.ts
+++ b/templates/index-dom.spec.ts
@@ -1,0 +1,32 @@
+import { render, RenderResult } from '@testing-library/svelte';
+import Index from './index.svelte';
+
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * An example test suite outlining the usage of
+ * `describe()`, `beforeEach()`, `test()` and `expect()`
+ *
+ * @see https://jestjs.io/docs/getting-started
+ * @see https://github.com/testing-library/jest-dom
+ */
+
+describe('Index', () => {
+
+  let renderedComponent: RenderResult;
+
+  beforeEach(() => {
+    renderedComponent = render(Index);
+  });
+
+  describe('once the component has been rendered', () => {
+
+    test('should show the proper heading', () => {
+      expect(renderedComponent.getByText('Welcome to SvelteKit')).toBeInTheDocument();
+    });
+
+  });
+
+});

--- a/templates/index.spec.js
+++ b/templates/index.spec.js
@@ -1,12 +1,24 @@
 /**
- * @jest-environment jsdom
+ * An example test suite outlining the usage of
+ * `describe()`, `beforeEach()`, `test()` and `expect()`
+ *
+ * @see https://jestjs.io/docs/getting-started
  */
 
-import '@testing-library/jest-dom/extend-expect';
-import { render } from '@testing-library/svelte';
-import index from './index.svelte';
+describe('Index', () => {
 
-test('shows proper heading when rendered', () => {
-  const { getByText } = render(index);
-  expect(getByText('Hello world!')).toBeInTheDocument();
+  let isTestSuitePassing = false;
+
+  beforeEach(() => {
+    isTestSuitePassing = true;
+  });
+
+  describe('isTestSuitePassing', () => {
+
+    test('should be true', () => {
+      expect(isTestSuitePassing).toBe(true);
+    });
+
+  });
+
 });

--- a/templates/index.spec.ts
+++ b/templates/index.spec.ts
@@ -1,12 +1,24 @@
 /**
- * @jest-environment jsdom
+ * An example test suite outlining the usage of
+ * `describe()`, `beforeEach()`, `test()` and `expect()`
+ *
+ * @see https://jestjs.io/docs/getting-started
  */
 
-import '@testing-library/jest-dom/extend-expect';
-import { render } from '@testing-library/svelte';
-import index from './index.svelte';
+describe('Index', () => {
 
-test('shows proper heading when rendered', () => {
-  const { getByText } = render(index);
-  expect(getByText('Hello world!')).toBeInTheDocument();
+  let isTestSuitePassing = false;
+
+  beforeEach(() => {
+    isTestSuitePassing = true;
+  });
+
+  describe('isTestSuitePassing', () => {
+
+    test('should be true', () => {
+      expect(isTestSuitePassing).toBe(true);
+    });
+
+  });
+
 });

--- a/templates/jest.config.json
+++ b/templates/jest.config.json
@@ -7,5 +7,6 @@
     "^\\$lib(.*)$": "<rootDir>/src/lib$1",
     "^\\$app(.*)$": ["<rootDir>/.svelte-kit/dev/runtime/app$1", "<rootDir>/.svelte-kit/build/runtime/app$1"]
   },
+  "extensionsToTreatAsEsm": [".svelte"],
   "moduleFileExtensions": ["js", "svelte"]
 }

--- a/templates/tsconfig.spec.json
+++ b/templates/tsconfig.spec.json
@@ -1,11 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "isolatedModules": false,
-    "lib": [
-      "es2020",
-      "DOM"
-    ]
+    "isolatedModules": false
   },
   "exclude": [
     "src/**"


### PR DESCRIPTION
Fix examples and v27 Jest support / ESM.

- Resolves #19 
- Resolves #22

### Changelog
- Add new `--jsdom` flag / option
    - Enables the user to specify whether they want per-test environment config with `@jest-environment` data-block, or to default to `jsdom` within `jest.config.json`.
- Ensure Jest DOM `@types` are only installed if both `ts` and `jest-dom` option are true
- Add ESM specific configuration for Jest:
    - Use `--experimental-vm-modules` flag when running Jest
    - Enable `useESM` configuration property for `ts-jest`
    - Force `.mjs` transformer usage in `jest.config.json` for `svelte-jester`. See https://github.com/rossyman/svelte-add-jest/issues/19#issuecomment-916218761
    - Add `.svelte` extensions to Jest `extensionsToTreatAsEsm`; and `.ts` depending on the TS option
- Improve example test files for a mixture of TS, JS and JS DOM configurations
- Remove divergence of `lib` property within `tsconfig.spec.json` to extend from `tsconfig.json`