### PR TITLE
[enhancement: #14] Compatibility with Vite import.meta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rossyman/svelte-add-jest",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "SvelteKit adder for Jest unit testing",
   "license": "MIT",
   "keywords": [

--- a/preset.ts
+++ b/preset.ts
@@ -166,8 +166,8 @@ class SvelteJestAdder extends Adder {
 
   protected readonly REQUIRED_DEPENDENCIES: Dependencies = {
     '@babel/core': {version: '^7.14.0', type: 'DEV'},
-    '@babel/preset-env': {version: '^7.14.0', type: 'DEV'},
     'jest': {version: '^27.0.0', type: 'DEV'},
+    'babel-plugin-transform-vite-meta-env': {version: '^1.0.1', type: 'DEV'},
     'babel-jest': {version: '^27.0.0', type: 'DEV'},
     'svelte-jester': {version: '^2.0.1', type: 'DEV'},
     '@testing-library/svelte': {version: '^3.0.0', type: 'DEV'},
@@ -243,7 +243,10 @@ class SvelteJestAdder extends Adder {
 
     Preset
       .editJson('package.json')
-      .merge({scripts: {'test': 'NODE_OPTIONS=--experimental-vm-modules jest src --config jest.config.json', 'test:watch': 'npm run test -- --watch'}})
+      .merge({scripts: {
+        'test': 'NODE_OPTIONS=--experimental-vm-modules jest src --config jest.config.json',
+        'test:watch': 'npm run test -- --watch'
+      }})
       .withTitle('Adding test scripts to package.json');
 
     Preset

--- a/templates/.babelrc
+++ b/templates/.babelrc
@@ -1,12 +1,3 @@
 {
-  "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "targets": {
-          "node": "current"
-        }
-      }
-    ]
-  ]
+  "plugins": ["babel-plugin-transform-vite-meta-env"]
 }

--- a/templates/index-dom.spec.js
+++ b/templates/index-dom.spec.js
@@ -24,7 +24,7 @@ describe('Index', () => {
   describe('once the component has been rendered', () => {
 
     test('should show the proper heading', () => {
-      expect(renderedComponent.getByText('Welcome to SvelteKit')).toBeInTheDocument();
+      expect(renderedComponent.getByText('SvelteKit', {exact: false})).toBeInTheDocument();
     });
 
   });

--- a/templates/index-dom.spec.ts
+++ b/templates/index-dom.spec.ts
@@ -24,7 +24,7 @@ describe('Index', () => {
   describe('once the component has been rendered', () => {
 
     test('should show the proper heading', () => {
-      expect(renderedComponent.getByText('Welcome to SvelteKit')).toBeInTheDocument();
+      expect(renderedComponent.getByText('SvelteKit', {exact: false})).toBeInTheDocument();
     });
 
   });

--- a/templates/index.spec.js
+++ b/templates/index.spec.js
@@ -1,3 +1,10 @@
+import { render } from '@testing-library/svelte';
+import Index from './index.svelte';
+
+/**
+ * @jest-environment jsdom
+ */
+
 /**
  * An example test suite outlining the usage of
  * `describe()`, `beforeEach()`, `test()` and `expect()`
@@ -7,16 +14,16 @@
 
 describe('Index', () => {
 
-  let isTestSuitePassing = false;
+  let renderedComponent;
 
   beforeEach(() => {
-    isTestSuitePassing = true;
+    renderedComponent = render(Index);
   });
 
-  describe('isTestSuitePassing', () => {
+  describe('once the component has been rendered', () => {
 
-    test('should be true', () => {
-      expect(isTestSuitePassing).toBe(true);
+    test('should show the proper heading', () => {
+      expect(renderedComponent.getByText('SvelteKit', {exact: false})).toBeDefined();
     });
 
   });

--- a/templates/index.spec.ts
+++ b/templates/index.spec.ts
@@ -1,3 +1,10 @@
+import { render, RenderResult } from '@testing-library/svelte';
+import Index from './index.svelte';
+
+/**
+ * @jest-environment jsdom
+ */
+
 /**
  * An example test suite outlining the usage of
  * `describe()`, `beforeEach()`, `test()` and `expect()`
@@ -7,16 +14,16 @@
 
 describe('Index', () => {
 
-  let isTestSuitePassing = false;
+  let renderedComponent: RenderResult;
 
   beforeEach(() => {
-    isTestSuitePassing = true;
+    renderedComponent = render(Index);
   });
 
-  describe('isTestSuitePassing', () => {
+  describe('once the component has been rendered', () => {
 
-    test('should be true', () => {
-      expect(isTestSuitePassing).toBe(true);
+    test('should show the proper heading', () => {
+      expect(renderedComponent.getByText('SvelteKit', {exact: false})).toBeDefined();
     });
 
   });

--- a/templates/jest.config.json
+++ b/templates/jest.config.json
@@ -5,7 +5,10 @@
   },
   "moduleNameMapper": {
     "^\\$lib(.*)$": "<rootDir>/src/lib$1",
-    "^\\$app(.*)$": ["<rootDir>/.svelte-kit/dev/runtime/app$1", "<rootDir>/.svelte-kit/build/runtime/app$1"]
+    "^\\$app(.*)$": [
+      "<rootDir>/.svelte-kit/dev/runtime/app$1",
+      "<rootDir>/.svelte-kit/build/runtime/app$1"
+    ]
   },
   "extensionsToTreatAsEsm": [".svelte"],
   "moduleFileExtensions": ["js", "svelte"]


### PR DESCRIPTION
Add compatibility with Vite `import.meta`. There's a wider discussion ongoing about how to use runtime modules outside of the context of a built svelte application. I outlined the current solutions here: https://github.com/rossyman/svelte-add-jest/issues/14#issuecomment-916377903 and I'll continue to track https://github.com/sveltejs/kit/issues/1485

Resolves #14 

### Changelog
- Add `babel-plugin-transform-vite-meta-env` dependency
- Update example test files based on comment: https://github.com/rossyman/svelte-add-jest/pull/23#discussion_r705536308