### PR TITLE
[bug: #27] Move JSDom comments to top of spec files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rossyman/svelte-add-jest",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "SvelteKit adder for Jest unit testing",
   "license": "MIT",
   "keywords": [

--- a/templates/index-dom.spec.js
+++ b/templates/index-dom.spec.js
@@ -1,9 +1,9 @@
-import { render } from '@testing-library/svelte';
-import Index from './index.svelte';
-
 /**
  * @jest-environment jsdom
  */
+
+import { render } from '@testing-library/svelte';
+import Index from './index.svelte';
 
 /**
  * An example test suite outlining the usage of

--- a/templates/index-dom.spec.ts
+++ b/templates/index-dom.spec.ts
@@ -1,9 +1,9 @@
-import { render, RenderResult } from '@testing-library/svelte';
-import Index from './index.svelte';
-
 /**
  * @jest-environment jsdom
  */
+
+import { render, RenderResult } from '@testing-library/svelte';
+import Index from './index.svelte';
 
 /**
  * An example test suite outlining the usage of


### PR DESCRIPTION
Move JSDom comments to top of spec files and bump version by two to include changes in #30

Resolves #27 