### PR TITLE
[enhancement: #26] Don't use relative modules path for svelte-jester transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rossyman/svelte-add-jest",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "SvelteKit adder for Jest unit testing",
   "license": "MIT",
   "keywords": [

--- a/preset.ts
+++ b/preset.ts
@@ -201,7 +201,7 @@ class SvelteJestAdder extends Adder {
     Preset
       .editJson('jest.config.json').merge({
         transform: {
-          '^.+\\.svelte$': ['./node_modules/svelte-jester/dist/transformer.mjs', {preprocess: true}],
+          '^.+\\.svelte$': ['svelte-jester/dist/transformer.mjs', {preprocess: true}],
           '^.+\\.ts$': 'ts-jest'
         },
         moduleFileExtensions: ['ts'],


### PR DESCRIPTION
Don't use relative path for svelte-jester transformer. Resolves #26 

### Changelog
- Remove reference to `node_modules` in transformers